### PR TITLE
Move the check for shadowOutputDir into globalSetup

### DIFF
--- a/jest-preset.js
+++ b/jest-preset.js
@@ -1,11 +1,4 @@
 const path = require('path')
-const { getProjectConfig } = require('./utils')
-
-const { globals } = getProjectConfig()
-
-if (!globals || !globals.shadowOutputDir || !globals.serverUrl) {
-  throw new Error('You must set the global config variables shadowOutputDir and serverUrl')
-}
 
 module.exports = {
   moduleFileExtensions: ['clj', 'cljs', 'js'],

--- a/jest.globalSetup.js
+++ b/jest.globalSetup.js
@@ -18,6 +18,12 @@ async function fetchUntilAvailable(serverUrl) {
 module.exports = async function globalSetup() {
   const { globals } = await getProjectConfig()
 
+  if (!globals.shadowOutputDir) {
+    throw new Error(
+      'config.globals.shadowOutputDir must be set to the output-dir of your :jest shadow-cljs.edn build.'
+    )
+  }
+
   if (!globals.serverUrl) {
     throw new Error(
       'config.globals.serverUrl must be set to the server URL of the shadow compilation server. E.g. http://localhost:9001'


### PR DESCRIPTION
In one of our projects, we are now using multiple Jest presets (including `jest-preset-shadow`). If the other preset must be used as the preset config value -- meaning, it could not be imported and merged into the config object -- it was not possible to use `jest-preset-shadow` with it as well as `jest-preset.js` does some top level checks to ensure some config values are present, which won't work when requiring inside of the config itself.

To fix this and allow for importing `jest-preset-shadow` as a module, this PR moves the config value checks out of `jest-preset.js` and instead into `jest.globalSetup.js`, letting the checks happen at Jest runtime rather than startup. 