### PR TITLE
Remove slf4j and silence some more logs

### DIFF
--- a/cljest/deps.edn
+++ b/cljest/deps.edn
@@ -1,7 +1,6 @@
 {:deps {appliedscience/js-interop {:mvn/version "0.2.3"}
         cheshire/cheshire {:mvn/version "5.10.2"}
         com.taoensso/timbre {:mvn/version "5.2.1"}
-        com.fzakaria/slf4j-timbre {:mvn/version "0.3.21"}
         io.aviso/pretty {:mvn/version "1.3"}
         lambdaisland/deep-diff2 {:mvn/version "2.4.138"}
         metosin/malli {:mvn/version "0.10.1"}

--- a/cljest/src/cljest/compilation/server.clj
+++ b/cljest/src/cljest/compilation/server.clj
@@ -14,7 +14,9 @@
 ;; Jetty announces some debug information when it's imported, so to avoid this we require after telling it not
 ;; to announce.
 ;; Thanks to https://github.com/active-group/active-logger#jetty.
-(.setProperty (org.eclipse.jetty.util.log.Log/getProperties) "org.eclipse.jetty.util.log.announce" "false")
+(. System (setProperty "org.eclipse.jetty.util.log.announce" "false"))
+(. System (setProperty "org.eclipse.jetty.util.log.class" "org.eclipse.jetty.util.log.StdErrLog"))
+(. System (setProperty "org.eclipse.jetty.LEVEL" "OFF"))
 
 (require '[ring.adapter.jetty :refer [run-jetty]])
 


### PR DESCRIPTION
This PR removes the `slf4j` package for Timbre and silences a few more logs. I couldn't figure out how to silence Undertow logs yet, so that'll come later.