### PR TITLE
Always recreate mocks inside of `setup-mocks`

### DIFF
--- a/cljest/package-lock.json
+++ b/cljest/package-lock.json
@@ -23,7 +23,7 @@
       }
     },
     "../jest-preset-cljest": {
-      "version": "1.0.0-alpha2",
+      "version": "1.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/cljest/src/cljest/helpers/core.clj
+++ b/cljest/src/cljest/helpers/core.clj
@@ -7,13 +7,14 @@
   [start finish bindings & body]
   (let [names (take-nth 2 bindings)
         vals (take-nth 2 (drop 1 bindings))
+        wrapped-vals (map (fn [v] (list 'fn [] v)) vals)
         orig-val-syms (for [_ names] (gensym))
         temp-val-syms (for [_ names] (gensym))
         binds (map vector names temp-val-syms)
         redefs (reverse (map vector names orig-val-syms))
-        bind-value (fn [[k v]] (list 'set! k v))]
+        bind-value (fn [[k v]] (list 'set! k (list v)))]
     `(let [~@(interleave orig-val-syms names)
-           ~@(interleave temp-val-syms vals)
+           ~@(interleave temp-val-syms wrapped-vals)
            ~start #(do ~@(map bind-value binds))
            ~finish #(do ~@(map bind-value redefs))]
        ~@body)))


### PR DESCRIPTION
This PR fixes a `setup-mocks` bug which caused the bindings to not always be recreated for each test case, instead only being created once and being reused. This allows `setup-mocks` to be used in cases where something stateful is being mocked, such as a JS class instance.