### PR TITLE
Improve build process

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,26 @@ jobs:
       - name: Compile and run cljest tests
         run: make jest-ci
 
+  cljest-analyze:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cljest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@9.5
+        with:
+          cli: 1.11.1.1224
+      - name: Analyze with cljdoc-analyzer
+        run: make analyze
+
   jest-preset-cljest-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ node_modules/
 .shadow-cljs/
 .cpcache/
 .lsp/
+
+cljest/dist/
 cljest/reports/
-pom.xml
-cljest/target

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# Next
+
+## Improvements
+
+- [Fix `cljdoc-analyze` build.](https://github.com/pitch-io/cljest/pull/38)
+
+## Internal
+
+- [Build using `clojure.tools.build` instead of `applied-science/deps-library`.](https://github.com/pitch-io/cljest/pull/38)
+- [Migrate from `applied-science/deps-library` to `deps-deploy` for Clojars deployment.](https://github.com/pitch-io/cljest/pull/38)
+
 # 1.1.0
 
 ## Features

--- a/cljest/Makefile
+++ b/cljest/Makefile
@@ -4,8 +4,7 @@ install:
 	npm i
 
 clean:
-	rm -rf .jest
-	rm -rf .shadow-cljs
+	rm -rf .jest .shadow-cljs .cpcache dist
 
 lint: install
 	clojure -A:fmt -M -m nsorg.cli src
@@ -19,6 +18,13 @@ lint-fix: install
 	./node_modules/.bin/eslint --fix .
 	./node_modules/.bin/prettier -w .
 
+build:
+	clojure -A:dev -X cljest.build/main
+
+analyze: clean build
+	clojure -A:dev -X cljest.analyze/main
+
+# TODO: make it publish the built stuff from above
 publish:
 	clj -A:publish -M -m deps-library.release
 

--- a/cljest/Makefile
+++ b/cljest/Makefile
@@ -18,15 +18,17 @@ lint-fix: install
 	./node_modules/.bin/eslint --fix .
 	./node_modules/.bin/prettier -w .
 
-build:
+build: clean
 	clojure -A:dev -X cljest.build/main
 
-analyze: clean build
+analyze: build
 	clojure -A:dev -X cljest.analyze/main
 
-# TODO: make it publish the built stuff from above
-publish:
-	clj -A:publish -M -m deps-library.release
+install-local-jar: build
+	clj -A:dev -X cljest.deploy/main
+
+publish-to-clojars: build
+	clj -A:dev -X cljest.deploy/main :clojars? true
 
 server:
 	clojure -A:test -X cljest.compilation/watch

--- a/cljest/build.edn
+++ b/cljest/build.edn
@@ -1,0 +1,10 @@
+{:lib com.pitch/cljest
+ :version "1.1.0"
+ :scm {:url "https://github.com/pitch-io/cljest"
+       :connection "scm:git:https://github.com/pitch-io/cljest.git"
+       :developerConnection "scm:git:git@github.com:pitch-io/cljest.git"}
+ :src-dirs ["src"]
+ :ignore [".*_test.cljs"]
+ :extra-paths ["../readme.md" "../docs"]
+ :optional-deps {re-frame/re-frame {:mvn/version "1.3.0"}
+                 reagent/reagent {:mvn/version "1.2.0"}}}

--- a/cljest/deps.edn
+++ b/cljest/deps.edn
@@ -15,7 +15,8 @@
  :aliases {:fmt {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.2"}
                               nsorg-cli/nsorg-cli {:mvn/version "0.3.1"}}}
            :dev {:extra-deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}
-                              io.github.cljdoc/cljdoc-analyzer {:git/sha "2983ed108d9a44ab1c26cd0f4a0d85425893bb62"}}
+                              io.github.cljdoc/cljdoc-analyzer {:git/sha "2983ed108d9a44ab1c26cd0f4a0d85425893bb62"}
+                              slipset/deps-deploy {:mvn/version "0.2.1"}}
                  :extra-paths ["dev"]}
            :test {:extra-paths ["example_tests"]
                   :extra-deps {com.pitch/uix.core {:mvn/version "0.8.1"}

--- a/cljest/deps.edn
+++ b/cljest/deps.edn
@@ -14,7 +14,9 @@
  :paths ["src"]
  :aliases {:fmt {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.2"}
                               nsorg-cli/nsorg-cli {:mvn/version "0.3.1"}}}
-           :publish {:extra-deps {appliedscience/deps-library {:mvn/version "0.3.4"}}}
+           :dev {:extra-deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}
+                              io.github.cljdoc/cljdoc-analyzer {:git/sha "2983ed108d9a44ab1c26cd0f4a0d85425893bb62"}}
+                 :extra-paths ["dev"]}
            :test {:extra-paths ["example_tests"]
                   :extra-deps {com.pitch/uix.core {:mvn/version "0.8.1"}
                                com.pitch/uix.dom {:mvn/version "0.8.1"}

--- a/cljest/dev/cljest/analyze.clj
+++ b/cljest/dev/cljest/analyze.clj
@@ -1,0 +1,12 @@
+(ns cljest.analyze
+  (:require cljdoc-analyzer.cljdoc-main
+            [cljest.build :as build]))
+
+(defn main
+  [& _]
+  (let [build-config (build/get-build-config)
+        analysis-config {:version (:version build-config)
+                         :project (str (:lib build-config))
+                         :jarpath (build/jar-path)
+                         :pompath (build/pom-path)}]
+    (cljdoc-analyzer.cljdoc-main/-main (str analysis-config))))

--- a/cljest/dev/cljest/analyze.clj
+++ b/cljest/dev/cljest/analyze.clj
@@ -3,6 +3,8 @@
             [cljest.build :as build]))
 
 (defn main
+  "Runs a `cljdoc-analyzer` analysis. Requires the JAR and POM to be built
+  (the `cljest.build/main` function needs to be run first)."
   [& _]
   (let [build-config (build/get-build-config)
         analysis-config {:version (:version build-config)

--- a/cljest/dev/cljest/build.clj
+++ b/cljest/dev/cljest/build.clj
@@ -60,7 +60,7 @@
 (defn main
   "Builds the JAR and POM files for the current version of `cljest`, as defined in `build.edn`."
   [& _]
-  (let [{:keys [version optional-deps lib extra-paths ignore src-dirs]} (get-build-config)
+  (let [{:keys [version optional-deps lib extra-paths ignore src-dirs scm]} (get-build-config)
         basis (tools.build.api/create-basis {:project "deps.edn"
                                              ;; `optional-deps` are still added to the POM, so that tools such as
                                              ;; `cljdoc-analyzer` can work correctly, but are marked as "provided",
@@ -106,5 +106,6 @@
                                 :lib lib
                                 :version version
                                 :basis basis
+                                :scm scm
                                 :src-dirs ["src"]})))
 

--- a/cljest/dev/cljest/build.clj
+++ b/cljest/dev/cljest/build.clj
@@ -58,6 +58,7 @@
       (throw (ex-info (str "POM file for cljest does not exist. Ensure that cljest has been built.") {})))))
 
 (defn main
+  "Builds the JAR and POM files for the current version of `cljest`, as defined in `build.edn`."
   [& _]
   (let [{:keys [version optional-deps lib extra-paths ignore src-dirs]} (get-build-config)
         basis (tools.build.api/create-basis {:project "deps.edn"

--- a/cljest/dev/cljest/build.clj
+++ b/cljest/dev/cljest/build.clj
@@ -1,0 +1,109 @@
+(ns cljest.build
+  (:require [clojure.data.xml :as xml]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.build.api :as tools.build.api]
+            [clojure.tools.build.tasks.write-pom :as tools.build.tasks.write-pom]))
+
+;; Adapted from https://github.com/mentat-collective/Mafs.cljs/blob/60a074ee8720c3252f1364cf8ea7a3fdac3e6c87/build.clj#L7-L15
+(xml/alias-uri 'pom "http://maven.apache.org/POM/4.0.0")
+
+(alter-var-root
+ #'tools.build.tasks.write-pom/to-dep
+ (fn [orig]
+   ;; This isn't really clean. `to-dep` seems to drop `original?` because of the `?`,
+   ;; but that's an implementation detail. Since this whole thing is a hack it's
+   ;; "fine".
+   (fn [[_ {:keys [optional?]} :as pair]]
+     (cond-> (orig pair)
+       optional?
+       (conj [::pom/scope "provided"])))))
+
+(defn get-build-config
+  "Reads the build config from `build.edn`. Assumes you execute whatever uses this
+  in the same pwd as where the file lives."
+  []
+  (-> "build.edn"
+      io/file
+      slurp
+      edn/read-string))
+
+(defn ^:private lib->group-id
+  [lib]
+  (-> lib
+      str
+      (str/split #"/")
+      first))
+
+(defn jar-path
+  "Returns the built JAR path. Throws if a JAR for the current build version
+  doesn't exist."
+  []
+  (let [{:keys [lib version]} (get-build-config)
+        raw-file (io/file (str "dist/" lib "-" version ".jar"))]
+    (if (.exists raw-file)
+      (.getCanonicalPath raw-file)
+      (throw (ex-info (str "JAR file for cljest " version " does not exist. Ensure that cljest has been built.") {})))))
+
+(defn pom-path
+  "Returns the generated POM path. Throws if a POM for the current build version
+  doesn't exist."
+  []
+  (let [{:keys [lib]} (get-build-config)
+        group-id (lib->group-id lib)
+        raw-file (io/file (str "dist/" group-id "/pom.xml"))]
+    (if (.exists raw-file)
+      (.getCanonicalPath raw-file)
+      (throw (ex-info (str "POM file for cljest does not exist. Ensure that cljest has been built.") {})))))
+
+(defn main
+  [& _]
+  (let [{:keys [version optional-deps lib extra-paths ignore src-dirs]} (get-build-config)
+        basis (tools.build.api/create-basis {:project "deps.edn"
+                                             ;; `optional-deps` are still added to the POM, so that tools such as
+                                             ;; `cljdoc-analyzer` can work correctly, but are marked as "provided",
+                                             ;; meaning they are "provided" by the user. This isn't supported in
+                                             ;; `deps.edn` or in `write-pom` (yet?), so until it is supported we need
+                                             ;; to hack around it.
+                                             ;;
+                                             ;; This is hacky for a couple of reasons. 1. The obvious: we need to alter
+                                             ;; `tools.build.tasks.write-pom/to-dep` to understand `optional?`; and,
+                                             ;; 2. the `optional?` is implicitly dropped from the POM generation because
+                                             ;; POM properties aren't munged and instead silently dropped at some point if
+                                             ;; they can't be serialized.
+                                             ;;
+                                             ;; I think this is okay since whatever the official solution is will likely
+                                             ;; require some change anyway, so it's fine to be hacky here.
+                                             ;;
+                                             ;; See https://ask.clojure.org/index.php/9110 and https://ask.clojure.org/index.php/12817.
+                                             :extra {:deps (->> optional-deps
+                                                                (map (fn [[k v]]
+                                                                       [k (assoc v :optional? true)]))
+                                                                (into {}))}})
+        jar-dir "dist/build_files/jar"
+        pom-dir (str "dist/" (lib->group-id lib))]
+    (tools.build.api/copy-dir {:src-dirs src-dirs
+                               :target-dir jar-dir
+                               :ignores (map re-pattern ignore)})
+
+    (doseq [path extra-paths]
+      (let [instance (io/file path)
+            dir? (.isDirectory instance)]
+        (if dir?
+          (tools.build.api/copy-dir {:target-dir (str jar-dir "/" (.getName instance))
+                                     :src-dirs [path]})
+          (tools.build.api/copy-file {:target (str jar-dir "/" (.getName instance))
+                                      :src path}))))
+
+    (tools.build.api/jar {:class-dir jar-dir
+                          :jar-file (str "dist/" lib "-" version ".jar")})
+
+    (tools.build.api/delete {:path "dist/build_files"})
+
+    (tools.build.api/write-pom {:target pom-dir
+                                :lib lib
+                                :version version
+                                :basis basis
+                                :src-dirs ["src"]})))
+

--- a/cljest/dev/cljest/deploy.clj
+++ b/cljest/dev/cljest/deploy.clj
@@ -1,0 +1,14 @@
+(ns cljest.deploy
+  (:require [cljest.build :as build]
+            [deps-deploy.deps-deploy :as deps-deploy]))
+
+(defn main
+  "Publishes the library. By default publishes locally, and publishes to
+  Clojars if called with `:clojars? true`."
+  [{:keys [clojars?]}]
+  (prn clojars?)
+  (let [installer (if clojars? :remote :local)]
+    (deps-deploy/deploy {:artifact (build/jar-path)
+                         :pom-file (build/pom-path)
+                         :sign-release? false
+                         :installer installer})))

--- a/cljest/package-lock.json
+++ b/cljest/package-lock.json
@@ -23,7 +23,7 @@
       }
     },
     "../jest-preset-cljest": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/cljest/release.edn
+++ b/cljest/release.edn
@@ -1,4 +1,0 @@
-{:group-id "com.pitch"
- :artifact-id "cljest"
- :version "1.1.0"
- :scm-url "https://github.com/pitch-io/cljest"}

--- a/cljest/src/cljest/compilation/config.clj
+++ b/cljest/src/cljest/compilation/config.clj
@@ -79,7 +79,7 @@
                                 "\n\n"
                                 (str/join "\n" (map humanize-error errors)))))))))
 
-(defn ^:private ^:no-doc load-config!
+(defn ^:private load-config!
   "Loads the cljest.edn file and coerces based on the Malli schema."
   []
   (let [config-io (io/file "cljest.edn")]
@@ -92,7 +92,7 @@
           config (coerce-config-with-pretty-exception! raw-config)]
       (reset! !config config))))
 
-(defn ^:no-doc get-config!
+(defn get-config!
   "Returns the coerced config. If it hasn't been loaded yet, load it."
   []
   (if-not @!config


### PR DESCRIPTION
This PR updates the build process by building directly with `tools.build`, instead of building using `deps-release`, and adds support for analyzing using `cljdoc-analyze` to ensure that the `cljdoc` build correctly works.

Fixes #36 . 

# TODOs

- [x] Create a deploy function
- [x] Fix analysis failures