### PR TITLE
Add current git revision to POM file

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 1.1.3
+
+This version and 1.1.2 have no user facing changes except that they make the `cljdoc` build work completely, as in `1.1.1` while the analysis worked, the docs didn't.
+
+## Internal
+
+- [Use `clojure` rather than `clj` and add update `scm.connection` value to use `scm:git:git...`.](https://github.com/pitch-io/cljest/pull/42)
+- [Add git revision to POM file.](https://github.com/pitch-io/cljest/pull/43)
+
 # 1.1.1
 
 ## Improvements

--- a/cljest/build.edn
+++ b/cljest/build.edn
@@ -1,5 +1,5 @@
 {:lib com.pitch/cljest
- :version "1.1.2"
+ :version "1.1.3"
  :scm {:url "https://github.com/pitch-io/cljest"
        :connection "scm:git:git://github.com/pitch-io/cljest.git"
        :developerConnection "scm:git:git@github.com:pitch-io/cljest.git"}

--- a/cljest/dev/cljest/build.clj
+++ b/cljest/dev/cljest/build.clj
@@ -83,7 +83,8 @@
                                                                        [k (assoc v :optional? true)]))
                                                                 (into {}))}})
         jar-dir "dist/build_files/jar"
-        pom-dir (str "dist/" (lib->group-id lib))]
+        pom-dir (str "dist/" (lib->group-id lib))
+        git-rev (tools.build.api/git-process {:git-args ["rev-parse" "HEAD"]})]
     (tools.build.api/copy-dir {:src-dirs src-dirs
                                :target-dir jar-dir
                                :ignores (map re-pattern ignore)})
@@ -106,6 +107,6 @@
                                 :lib lib
                                 :version version
                                 :basis basis
-                                :scm scm
+                                :scm (assoc scm :tag git-rev)
                                 :src-dirs ["src"]})))
 

--- a/cljest/package-lock.json
+++ b/cljest/package-lock.json
@@ -23,7 +23,7 @@
       }
     },
     "../jest-preset-cljest": {
-      "version": "1.1.0",
+      "version": "1.1.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/jest-preset-cljest/package-lock.json
+++ b/jest-preset-cljest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jest-preset-cljest",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-preset-cljest",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",

--- a/jest-preset-cljest/package.json
+++ b/jest-preset-cljest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-preset-cljest",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A preset for Jest to allow compiling ClojureScript tests",
   "main": "jest-preset.js",
   "scripts": {},


### PR DESCRIPTION
This PR adds the current git revision as the `scm.tag` value in the POM file. This allows cljdoc to find the right commit and show the readme and docs correctly. 