### PR TITLE
Correctly reset original binding values when using `setup-mocks`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 1.1.4
+
+## Bugfixes
+
+- [Fix `setup-mocks` and `with-mocks` regression when resetting to the original bindings.](https://github.com/pitch-io/cljest/pull/45)
+
 # 1.1.3
 
 This version and 1.1.2 have no user facing changes except that they make the `cljdoc` build work completely, as in `1.1.1` while the analysis worked, the docs didn't.

--- a/cljest/build.edn
+++ b/cljest/build.edn
@@ -1,5 +1,5 @@
 {:lib com.pitch/cljest
- :version "1.1.3"
+ :version "1.1.4"
  :scm {:url "https://github.com/pitch-io/cljest"
        :connection "scm:git:git://github.com/pitch-io/cljest.git"
        :developerConnection "scm:git:git@github.com:pitch-io/cljest.git"}

--- a/cljest/package-lock.json
+++ b/cljest/package-lock.json
@@ -23,7 +23,7 @@
       }
     },
     "../jest-preset-cljest": {
-      "version": "1.1.3",
+      "version": "1.1.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/cljest/src/cljest/helpers/core_test.cljs
+++ b/cljest/src/cljest/helpers/core_test.cljs
@@ -31,6 +31,14 @@
         (swap! counter dec)
         @counter)))
 
+  ;; The presence of this function validates mocking the symbol
+  ;; doesn't cause the function to be called. See https://github.com/pitch-io/cljest/issues/44
+  ;; The same could be done with a primitive value that can't be `.call`-ed, but this
+  ;; will show a nicer error.
+  (defn ^:private my-super-cool-fn
+    []
+    (throw (js/Error. "This function should never be called!")))
+
   (h/setup-mocks [something-stateful (let [counter (atom 0)]
                                        (fn []
                                          (swap! counter (partial + 2))
@@ -39,7 +47,9 @@
                   something-else-stateful (let [counter (atom 0)]
                                             (fn []
                                               (swap! counter #(- % 2))
-                                              @counter))])
+                                              @counter))
+
+                  my-super-cool-fn (constantly nil)])
 
   (it "works"
     (is (= 2 (something-stateful)))

--- a/jest-preset-cljest/package-lock.json
+++ b/jest-preset-cljest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jest-preset-cljest",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-preset-cljest",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",

--- a/jest-preset-cljest/package.json
+++ b/jest-preset-cljest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-preset-cljest",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A preset for Jest to allow compiling ClojureScript tests",
   "main": "jest-preset.js",
   "scripts": {},


### PR DESCRIPTION
This PR fixes `setup-mocks` by correctly resetting the original binding values. Previously they would be called as if they were functions, which can cause issues in many cases.